### PR TITLE
Added http timeouts and AWS client retry config

### DIFF
--- a/aws/config/config.go
+++ b/aws/config/config.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/disneystreaming/go-ssmhelpers/util/httpx"
+)
+
+// NewDefaultConfig will return default AWS Configs that are meant to be
+// merged in. Luckily both the deprecated session.New() and session.NewSession()
+// take `cfgs ...*aws.Config` then merge them in.
+//
+// This means we can change our sessions to be `session.New(<whatver>, session.NewDefaultConfig())
+// If we need to override it we can swap order (last config's value wins)
+func NewDefaultConfig() *aws.Config {
+	return &aws.Config{
+		HTTPClient: httpx.NewDefaultClient(),
+		Retryer: &client.DefaultRetryer{
+			NumMaxRetries: 10,
+		},
+	}
+}
+
+// NewDefaultConfigWithRegion returns the same config as NewDefaultConfig, but allows a user to specify a region as well
+func NewDefaultConfigWithRegion(region string) *aws.Config {
+	return &aws.Config{
+		Region:     aws.String(region),
+		HTTPClient: httpx.NewDefaultClient(),
+		Retryer: &client.DefaultRetryer{
+			NumMaxRetries: 10,
+		},
+	}
+}

--- a/aws/session/session.go
+++ b/aws/session/session.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/disneystreaming/go-ssmhelpers/aws/config"
 )
 
 // NewPoolSafe is used to create a pool of AWS sessions with different profile/region permutations
@@ -74,17 +74,18 @@ func newSession(profile string, region string) (newSession *session.Session) {
 		newSession = session.Must(
 			session.NewSessionWithOptions(
 				session.Options{
-					SharedConfigState: session.SharedConfigEnable,
+					Config:            *config.NewDefaultConfigWithRegion(region),
 					Profile:           profile,
-					Config: aws.Config{
-						Region: aws.String(region),
-					}}))
+					SharedConfigState: session.SharedConfigEnable,
+				}))
 	} else {
 		newSession = session.Must(
 			session.NewSessionWithOptions(
 				session.Options{
+					Config:            *config.NewDefaultConfig(),
+					Profile:           profile,
 					SharedConfigState: session.SharedConfigEnable,
-					Profile:           profile}))
+				}))
 	}
 
 	return newSession

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.13
 
 require (
 	github.com/aws/aws-sdk-go v1.27.3
-	github.com/disneystreaming/go-ssmhelpers v0.1.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/mitchellh/go-homedir v1.1.0

--- a/util/httpx/httpx.go
+++ b/util/httpx/httpx.go
@@ -1,0 +1,14 @@
+package httpx
+
+import (
+	"net/http"
+	"time"
+)
+
+// NewDefaultClient returns a new http client
+// configured with sane timeout because globals are bad
+func NewDefaultClient() *http.Client {
+	return &http.Client{
+		Timeout: 10 * time.Second,
+	}
+}

--- a/util/httpx/httpx_test.go
+++ b/util/httpx/httpx_test.go
@@ -1,0 +1,13 @@
+package httpx
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDefaultHTTPClient(t *testing.T) {
+	c := NewDefaultClient()
+	assert.Equal(t, 10*time.Second, c.Timeout)
+}


### PR DESCRIPTION
Fixes #4.

HTTP request timeout set to 10 seconds, AWS clients configured for 10 retries (in case of network issues/rate limiting/etc).