### PR TITLE
Clean up instance list retrieval

### DIFF
--- a/ssm/instance/fetch.go
+++ b/ssm/instance/fetch.go
@@ -1,8 +1,10 @@
 package instance
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/aws-sdk-go/service/ssm/ssmiface"
+	"github.com/disneystreaming/go-ssmhelpers/util/batch"
 )
 
 // getSSMInstances takes an SSM session and an *ssm.DescribeInstanceInformationInput object to get information about a given SSM-managed EC2 instance.
@@ -10,45 +12,78 @@ func getSSMInstances(session ssmiface.SSMAPI, input *ssm.DescribeInstanceInforma
 	return session.DescribeInstanceInformation(input)
 }
 
-// GetAllSSMInstances takes an SSM session and an *ssm.DescribeInstanceInformationInput object, and calls getSSMInstances() to query the SSM API for
-// information about a given SSM-managed EC2 instance. It also filters out any instances returned that are unresponsive to ping or not running Linux.
-// Filtering can only be done based on either instance information OR instance tags for any given instance of a query. As such, filtering of instances
-// by things like bamazon and env tags must be done after retrieving the instance information.
-func GetAllSSMInstances(session ssmiface.SSMAPI, input *ssm.DescribeInstanceInformationInput, checkLatestAgent bool) (output []*ssm.InstanceInformation, err error) {
-	// First call to set up NextToken
+// getSSMInstances takes an SSM session and an *ssm.DescribeInstanceInformationInput object to get information about a given SSM-managed EC2 instance.
+func getSSMInstancesPages(session ssmiface.SSMAPI, input *ssm.DescribeInstanceInformationInput) (output []*ssm.DescribeInstanceInformationOutput, err error) {
 	results, err := getSSMInstances(session, input)
+	if err != nil {
+		return nil, err
+	}
 
-	var allResults []*ssm.InstanceInformation
-	for _, v := range results.InstanceInformationList {
-		// Remove any instances that are unresponsive to ping or not running Linux
-		if checkLatestAgent {
-			if *v.PingStatus == "Online" && *v.PlatformType == "Linux" && *v.IsLatestVersion {
-				allResults = append(allResults, v)
-			}
-		} else {
-			if *v.PingStatus == "Online" && *v.PlatformType == "Linux" {
-				allResults = append(allResults, v)
-			}
+	output = append(output, results)
+
+	for results.NextToken != nil && *results.NextToken != "" && err == nil {
+		input.SetNextToken(*results.NextToken)
+		results, err = getSSMInstances(session, input)
+		if err != nil {
+			return output, err
+		}
+		output = append(output, results)
+	}
+
+	return output, err
+}
+
+// GetAllSSMInstances queries the SSM API for information about SSM-managed instances, and filters out any instances that are unresponsive to ping or not running Linux.
+// It can also check to determine if instances are running the latest SSM agent version, which is a prerequisite for connecting via start-session functionality.
+func GetAllSSMInstances(session ssmiface.SSMAPI, input *ssm.DescribeInstanceInformationInput, checkLatestAgent bool) (output []*ssm.InstanceInformation, err error) {
+	results, err := getSSMInstancesPages(session, input)
+
+	instanceIds := []*string{}
+	for _, page := range results {
+		for _, instanceInfo := range page.InstanceInformationList {
+			instanceIds = append(instanceIds, instanceInfo.InstanceId)
 		}
 	}
-	// Repeat call until we've paginated through all results
-	for results.NextToken != nil {
-		if *results.NextToken != "" {
-			input.SetNextToken(*results.NextToken)
+
+	// Create our batch function to iterate over the first batch of results
+	getInstanceBatch := func(min int, max int) (bool, error) {
+		// Set up our additional filters and second input
+		statusInput := &ssm.DescribeInstanceInformationInput{
+			Filters: []*ssm.InstanceInformationStringFilter{
+				{
+					Key:    aws.String("PingStatus"),
+					Values: aws.StringSlice([]string{"Online"}),
+				},
+				{
+					Key:    aws.String("PlatformTypes"),
+					Values: aws.StringSlice([]string{"Linux"}),
+				},
+				{
+					Key:    aws.String("InstanceIds"),
+					Values: instanceIds[min:max],
+				},
+			},
 		}
-		results, _ = getSSMInstances(session, input)
-		for _, v := range results.InstanceInformationList {
-			// Remove any instances are unresponsive to ping or not running Linux
-			if checkLatestAgent {
-				if *v.PingStatus == "Online" && *v.PlatformType == "Linux" && *v.IsLatestVersion {
-					allResults = append(allResults, v)
-				}
-			} else {
-				if *v.PingStatus == "Online" && *v.PlatformType == "Linux" {
-					allResults = append(allResults, v)
+
+		// Re-run query to filter out instances that are unresponsive to ping or not running Linux
+		results, err = getSSMInstancesPages(session, statusInput)
+		if err != nil {
+			return false, err
+		}
+
+		for _, instanceList := range results {
+			for _, v := range instanceList.InstanceInformationList {
+				if checkLatestAgent && *v.IsLatestVersion {
+					output = append(output, v)
+				} else if !checkLatestAgent {
+					output = append(output, v)
 				}
 			}
 		}
+		return true, nil
 	}
-	return allResults, err
+
+	err = batch.Chunk(len(instanceIds), 100, getInstanceBatch)
+
+	return output, err
 }

--- a/ssm/instance/fetch_test.go
+++ b/ssm/instance/fetch_test.go
@@ -19,7 +19,7 @@ func TestGetAllSSMInstances(t *testing.T) {
 		ssmInput := &ssm.DescribeInstanceInformationInput{}
 		instances, _ := GetAllSSMInstances(mockSvc, ssmInput, true)
 
-		// Function should filter out any instances that are offline or not running Linux or do not have the latest agent version
+		// Function should filter out any instances that do not have the latest agent version
 		assert.Lenf(instances, 3, "Incorrect number of matching instances returned; got %d, expected 3", len(instances))
 	})
 
@@ -27,7 +27,7 @@ func TestGetAllSSMInstances(t *testing.T) {
 		ssmInput := &ssm.DescribeInstanceInformationInput{}
 		instances, _ := GetAllSSMInstances(mockSvc, ssmInput, false)
 
-		// Function should filter out any instances that are offline or not running Linux
+		// Function should return all instances, regardless of agent version
 		assert.Lenf(instances, 4, "Incorrect number of matching instances returned; got %d, expected 4", len(instances))
 	})
 

--- a/testing/ssm_mocks.go
+++ b/testing/ssm_mocks.go
@@ -103,20 +103,8 @@ func (m *MockSSMClient) DescribeInstanceInformation(input *ssm.DescribeInstanceI
 			InstanceInformationList: []*ssm.InstanceInformation{
 				{
 					PlatformType:    aws.String("Linux"),
-					PingStatus:      aws.String("Offline"),
-					InstanceId:      aws.String("i-23456"),
-					IsLatestVersion: aws.Bool(true),
-				},
-				{
-					PlatformType:    aws.String("Linux"),
 					PingStatus:      aws.String("Online"),
 					InstanceId:      aws.String("i-45678"),
-					IsLatestVersion: aws.Bool(true),
-				},
-				{
-					PlatformType:    aws.String("Windows"),
-					PingStatus:      aws.String("Offline"),
-					InstanceId:      aws.String("i-78901"),
 					IsLatestVersion: aws.Bool(true),
 				},
 				{
@@ -143,12 +131,6 @@ func (m *MockSSMClient) DescribeInstanceInformation(input *ssm.DescribeInstanceI
 				PlatformType:    aws.String("Linux"),
 				PingStatus:      aws.String("Online"),
 				InstanceId:      aws.String("i-34567"),
-				IsLatestVersion: aws.Bool(true),
-			},
-			{
-				PlatformType:    aws.String("Windows"),
-				PingStatus:      aws.String("Online"),
-				InstanceId:      aws.String("i-67890"),
 				IsLatestVersion: aws.Bool(true),
 			},
 		},


### PR DESCRIPTION
* Break out getSSMInstances pagination into separate function
* Move PingStatus/PlatformType checking to server-side filtering
* Clean up latest agent check
* Add batching to allow second pass filtering

The goal here is to move the filtering for PingStatus and PlatformType to the server side. It requires a second set of calls to the API, but since the rate limits for this are pretty high, we haven't seen any issues with it in testing.